### PR TITLE
Used exceptions to indicate errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ META-INF/
 target/
 settings.xml
 release.properties
+.DS_Store

--- a/src/main/java/org/rfc8452/aead/AesGcmSiv.java
+++ b/src/main/java/org/rfc8452/aead/AesGcmSiv.java
@@ -2,6 +2,7 @@ package org.rfc8452.aead;
 
 import org.rfc8452.authenticator.Polyval;
 
+import javax.crypto.AEADBadTagException;
 import javax.crypto.Cipher;
 import javax.crypto.spec.SecretKeySpec;
 import java.security.GeneralSecurityException;
@@ -91,7 +92,8 @@ public class AesGcmSiv implements AEAD
         {
             return deciphered;
         }
-        return null;
+
+        throw new AEADBadTagException();
     }
 
     @Override
@@ -99,7 +101,7 @@ public class AesGcmSiv implements AEAD
     {
         if (nonceWithCiphertext.length < NONCE_BYTE_LENGTH)
         {
-            return null;
+            throw new GeneralSecurityException("Ciphertext is too short");
         }
         final byte[] nonce = new byte[NONCE_BYTE_LENGTH];
         final byte[] ciphertext = new byte[nonceWithCiphertext.length - NONCE_BYTE_LENGTH];
@@ -117,10 +119,6 @@ public class AesGcmSiv implements AEAD
         final byte[] aad = Conversion.hexStringToBytes(aadHexString);
         final byte[] nonce = Conversion.hexStringToBytes(nonceHexString);
         final byte[] plaintext = open(ciphertext, aad, nonce);
-        if (null == plaintext)
-        {
-            return null;
-        }
         return Conversion.bytesToHexString(plaintext);
     }
 

--- a/src/test/java/org/rfc8452/aead/AesGcmSivTest.java
+++ b/src/test/java/org/rfc8452/aead/AesGcmSivTest.java
@@ -1,5 +1,6 @@
 package org.rfc8452.aead;
 
+import javax.crypto.AEADBadTagException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -59,8 +60,7 @@ class AesGcmSivTest
         final byte[] plaintext = new byte[] {1, 1};
         final byte[] aad = new byte[] {2, 2};
         final byte[] invalidAad = new byte[] {3, 3};
-        final byte[] deciphered = aead.open(aead.seal(plaintext, aad), invalidAad);
-        Assertions.assertNull(deciphered);
+        Assertions.assertThrows(AEADBadTagException.class, () -> aead.open(aead.seal(plaintext, aad), invalidAad));
     }
 
     @Test
@@ -70,8 +70,7 @@ class AesGcmSivTest
         final byte[] aad = new byte[] {2, 2};
         final byte[] ciphertext = aead.seal(plaintext, aad);
         aead.resetKey();
-        final byte[] deciphered = aead.open(ciphertext, aad);
-        Assertions.assertNull(deciphered);
+        Assertions.assertThrows(AEADBadTagException.class, () -> aead.open(ciphertext, aad));
     }
 
 }


### PR DESCRIPTION
In this change I introduced throwing exceptions on decryption errors instead of returning nulls. It will be easier to reason about the problem on the callers side.